### PR TITLE
## [6.2.1] - 2021-12-30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.2.1] - 2021-12-30
+
+### Bugfix
+
+- removed required `zstd` library for other compressions.
+
 ## [6.2.0] - 2021-12-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ By default `gzipper` compress **all the files** but you could use `include` or `
   - [Changelog](#changelog)
   - [Contribution](#contribution)
   - [Support](#support)
+  - [Prerequisites](#prerequisites)
+    - [MacOS/Linux/WSL (Windows Subsystem for Linux)](#macoslinuxwsl-windows-subsystem-for-linux)
 
 ## Install
 
@@ -499,4 +501,18 @@ I appreciate every contribution, just fork the repository and send the pull requ
 
 ## Support
 
-- Node.js >= 12
+- Node.js >= 14
+
+## Prerequisites
+
+If you want to use `--zstd` compression you have to make sure that the appropriate library is installed and available at your environment variable.
+`where zstd.exe` (Windows)
+`which zstd` (MacOS/Linux)
+
+If you didn't find executable `zstd` you have to install this manually.
+
+### MacOS/Linux/WSL (Windows Subsystem for Linux)
+Brew: `brew install zstd` (zstd only)
+      `brew install zlib` (whole library)
+
+APT: `sudo apt install zstd`

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gzipper",
   "packageManager": "yarn@3.1.1",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "description": "CLI for compressing files.",
   "main": "index.js",
   "scripts": {

--- a/src/Compress.worker.ts
+++ b/src/Compress.worker.ts
@@ -94,7 +94,7 @@ class CompressWorker {
     target: string,
     compressionInstance: CompressionType,
   ): Promise<Partial<CompressedFile>> {
-    const createCompression = compressionInstance.getCompression();
+    const createCompression = await compressionInstance.getCompression();
     let isCached = false;
     let isSkipped = false;
     const inputPath = path.join(target, filename);
@@ -135,7 +135,7 @@ class CompressWorker {
       if (isChanged) {
         await this.nativeStream.pipeline(
           fs.createReadStream(inputPath),
-          createCompression(),
+          createCompression,
           fs.createWriteStream(outputPath),
         );
 
@@ -153,7 +153,7 @@ class CompressWorker {
     } else {
       await this.nativeStream.pipeline(
         fs.createReadStream(inputPath),
-        createCompression(),
+        createCompression,
         fs.createWriteStream(outputPath),
       );
     }

--- a/src/compressions/Brotli.ts
+++ b/src/compressions/Brotli.ts
@@ -20,11 +20,10 @@ export class BrotliCompression extends Compression<BrotliOptions> {
   /**
    * Returns brotli compression instance in closure.
    */
-  getCompression(): () => zlib.BrotliCompress {
-    return (): zlib.BrotliCompress =>
-      zlib.createBrotliCompress({
-        params: this.compressionOptions,
-      });
+  getCompression(): zlib.BrotliCompress {
+    return zlib.createBrotliCompress({
+      params: this.compressionOptions,
+    });
   }
 
   /**

--- a/src/compressions/Compression.ts
+++ b/src/compressions/Compression.ts
@@ -1,8 +1,14 @@
 import zopfli from 'node-zopfli';
-import zstd from 'simple-zstd';
+import stream from 'stream';
 import zlib from 'zlib';
 
 import { CompressOptions } from '../interfaces';
+
+type CompressionType =
+  | zlib.BrotliCompress
+  | zlib.Gzip
+  | zopfli
+  | stream.Transform;
 
 export abstract class Compression<T> {
   compressionOptions: T = {} as T;
@@ -21,11 +27,7 @@ export abstract class Compression<T> {
   /**
    * Returns a compression instance in closure.
    */
-  abstract getCompression(): () =>
-    | zlib.BrotliCompress
-    | zlib.Gzip
-    | zopfli
-    | zstd.ZSTDCompress;
+  abstract getCompression(): CompressionType | Promise<CompressionType>;
 
   /**
    * Build compression options object [compressionOptions].

--- a/src/compressions/Deflate.ts
+++ b/src/compressions/Deflate.ts
@@ -20,8 +20,8 @@ export class DeflateCompression extends Compression<CompressionOptions> {
   /**
    * Returns deflate compression instance in closure.
    */
-  getCompression(): () => zlib.Deflate {
-    return (): zlib.Deflate => zlib.createDeflate(this.compressionOptions);
+  getCompression(): zlib.Deflate {
+    return zlib.createDeflate(this.compressionOptions);
   }
 
   /**

--- a/src/compressions/Gzip.ts
+++ b/src/compressions/Gzip.ts
@@ -20,8 +20,8 @@ export class GzipCompression extends Compression<CompressionOptions> {
   /**
    * Returns gzip compression instance in closure.
    */
-  getCompression(): () => zlib.Gzip {
-    return (): zlib.Gzip => zlib.createGzip(this.compressionOptions);
+  getCompression(): zlib.Gzip {
+    return zlib.createGzip(this.compressionOptions);
   }
 
   /**

--- a/src/compressions/Zopfli.ts
+++ b/src/compressions/Zopfli.ts
@@ -20,8 +20,8 @@ export class ZopfliCompression extends Compression<ZopfliOptions> {
   /**
    * Returns zopfli compression instance in closure.
    */
-  getCompression(): () => zopfli {
-    return (): zopfli => new zopfli('gzip', this.compressionOptions);
+  getCompression(): zopfli {
+    return new zopfli('gzip', this.compressionOptions);
   }
 
   /**

--- a/src/compressions/Zstd.ts
+++ b/src/compressions/Zstd.ts
@@ -1,4 +1,4 @@
-import zstd from 'simple-zstd';
+import stream from 'stream';
 
 import { Compression } from './Compression';
 import { CompressOptions, ZstdOptions } from '../interfaces';
@@ -20,9 +20,9 @@ export class ZstdCompression extends Compression<ZstdOptions> {
   /**
    * Returns zstd compression instance in closure.
    */
-  getCompression(): () => zstd.ZSTDCompress {
-    return (): zstd.ZSTDCompress =>
-      zstd.ZSTDCompress(this.compressionOptions.level);
+  async getCompression(): Promise<stream.Transform> {
+    const zstd = await import('simple-zstd');
+    return zstd.ZSTDCompress(this.compressionOptions.level);
   }
 
   /**


### PR DESCRIPTION
## [6.2.1] - 2021-12-30

### Bugfix

- removed required `zstd` library for other compressions.